### PR TITLE
NFC 읽은 데이터가 가끔 비어있는 경우 크래쉬 나는 현상 수정

### DIFF
--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -138,8 +138,6 @@ public class PassportReader : NSObject {
             }
         }
     }
-
-
 }
 
 @available(iOS 15, *)
@@ -158,7 +156,7 @@ extension PassportReader : NFCTagReaderSessionDelegate {
         Logger.passportReader.debug( "tagReaderSession:didInvalidateWithError - \(error.localizedDescription)" )
         self.readerSession?.invalidate()
         self.readerSession = nil
-        sessionDidBecomeActive = false
+        self.sessionDidBecomeActive = false
 
         if let readerError = error as? NFCReaderError, readerError.code == NFCReaderError.readerSessionInvalidationErrorUserCanceled
             && self.shouldNotReportNextReaderSessionInvalidationErrorUserCanceled {
@@ -292,6 +290,7 @@ extension PassportReader {
         self.updateReaderSessionMessage(alertMessage: NFCViewDisplayMessage.successfulRead)
         self.shouldNotReportNextReaderSessionInvalidationErrorUserCanceled = true
         self.readerSession?.invalidate()
+        self.readerSession = nil
 
         // If we have a masterlist url set then use that and verify the passport now
         self.passport.verifyPassport(masterListURL: self.masterListURL, useCMSVerification: self.passiveAuthenticationUsesOpenSSL)

--- a/Sources/NFCPassportReader/PassportReader.swift
+++ b/Sources/NFCPassportReader/PassportReader.swift
@@ -14,55 +14,27 @@ import UIKit
 import CoreNFC
 
 @available(iOS 15, *)
-public protocol PassportReaderTrackingDelegate: AnyObject {
-    func nfcTagDetected()
-    func readCardAccess(cardAccess: CardAccess)
-    func paceStarted()
-    func paceSucceeded()
-    func paceFailed()
-    func bacStarted()
-    func bacSucceeded()
-    func bacFailed()
-}
-
-@available(iOS 15, *)
-extension PassportReaderTrackingDelegate {
-    func nfcTagDetected() { /* default implementation */ }
-    func readCardAccess(cardAccess: CardAccess) { /* default implementation */ }
-    func paceStarted() { /* default implementation */ }
-    func paceSucceeded() { /* default implementation */ }
-    func paceFailed() { /* default implementation */ }
-    func bacStarted() { /* default implementation */ }
-    func bacSucceeded() { /* default implementation */ }
-    func bacFailed() { /* default implementation */ }
-}
-
-@available(iOS 15, *)
 public class PassportReader : NSObject {
     private typealias NFCCheckedContinuation = CheckedContinuation<NFCPassportModel, Error>
     private var nfcContinuation: NFCCheckedContinuation?
 
-    public weak var trackingDelegate: PassportReaderTrackingDelegate?
     private var passport : NFCPassportModel = NFCPassportModel()
-    
+
     private var readerSession: NFCTagReaderSession?
     private var currentlyReadingDataGroup : DataGroupId?
-    
+
     private var dataGroupsToRead : [DataGroupId] = []
     private var readAllDatagroups = false
     private var skipSecureElements = true
     private var skipCA = false
     private var skipPACE = false
-    
-    // Extended mode is used for reading eMRTD's that support extended length APDUs
-    private var useExtendedMode = false
 
     private var bacHandler : BACHandler?
     private var caHandler : ChipAuthenticationHandler?
     private var paceHandler : PACEHandler?
     private var mrzKey : String = ""
     private var dataAmountToReadOverride : Int? = nil
-    
+
     private var scanCompletedHandler: ((NFCPassportModel?, NFCPassportReaderError?)->())!
     private var nfcViewDisplayMessageHandler: ((NFCViewDisplayMessage) -> String?)?
     private var masterListURL : URL?
@@ -71,17 +43,18 @@ public class PassportReader : NSObject {
     // By default, Passive Authentication uses the new RFS5652 method to verify the SOD, but can be switched to use
     // the previous OpenSSL CMS verification if necessary
     public var passiveAuthenticationUsesOpenSSL : Bool = false
+    private var sessionDidBecomeActive = false
 
     public init( masterListURL: URL? = nil ) {
         super.init()
-        
+
         self.masterListURL = masterListURL
     }
-    
+
     public func setMasterListURL( _ masterListURL : URL ) {
         self.masterListURL = masterListURL
     }
-    
+
     // This function allows you to override the amount of data the TagReader tries to read from the NFC
     // chip. NOTE - this really shouldn't be used for production but is useful for testing as different
     // passports support different data amounts.
@@ -89,15 +62,15 @@ public class PassportReader : NSObject {
     public func overrideNFCDataAmountToRead( amount: Int ) {
         dataAmountToReadOverride = amount
     }
-    
-    public func readPassport( mrzKey : String, tags : [DataGroupId] = [], skipSecureElements : Bool = true, skipCA : Bool = false, skipPACE : Bool = false, useExtendedMode : Bool = false, customDisplayMessage : ((NFCViewDisplayMessage) -> String?)? = nil) async throws -> NFCPassportModel {
-        
+
+    public func readPassport( mrzKey : String, tags : [DataGroupId] = [], skipSecureElements : Bool = true, skipCA : Bool = false, skipPACE : Bool = false, customDisplayMessage : ((NFCViewDisplayMessage) -> String?)? = nil) async throws -> NFCPassportModel {
+
         self.passport = NFCPassportModel()
         self.mrzKey = mrzKey
         self.skipCA = skipCA
         self.skipPACE = skipPACE
-        self.useExtendedMode = useExtendedMode
-        
+
+        self.sessionDidBecomeActive = false
         self.dataGroupsToRead.removeAll()
         self.dataGroupsToRead.append( contentsOf:tags)
         self.nfcViewDisplayMessageHandler = customDisplayMessage
@@ -106,7 +79,7 @@ public class PassportReader : NSObject {
         self.bacHandler = nil
         self.caHandler = nil
         self.paceHandler = nil
-        
+
         // If no tags specified, read all
         if self.dataGroupsToRead.count == 0 {
             // Start off with .COM, will always read (and .SOD but we'll add that after), and then add the others from the COM
@@ -116,22 +89,57 @@ public class PassportReader : NSObject {
             // We are reading specific datagroups
             self.readAllDatagroups = false
         }
-        
+
         guard NFCNDEFReaderSession.readingAvailable else {
             throw NFCPassportReaderError.NFCNotSupported
         }
-        
+
         if NFCTagReaderSession.readingAvailable {
-            readerSession = NFCTagReaderSession(pollingOption: [.iso14443], delegate: self, queue: nil)
-            
-            self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.requestPresentPassport )
-            readerSession?.begin()
+            self.startSessionWithRetry()
         }
-        
+
         return try await withCheckedThrowingContinuation({ (continuation: NFCCheckedContinuation) in
             self.nfcContinuation = continuation
         })
     }
+
+    private func startSessionWithRetry(retryCount: Int = 3) {
+        guard retryCount > 0 else {
+            Logger.passportReader.error("startSessionWithRetry: retry count 0")
+            return
+        }
+
+        if let session = readerSession {
+            Logger.passportReader.debug("startSessionWithRetry: session exists")
+            session.invalidate()
+            readerSession = nil
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                guard let self = self else { return }
+                if !self.sessionDidBecomeActive {
+                    self.startSessionWithRetry(retryCount: retryCount - 1)
+                }
+            }
+            return
+        }
+
+        let session = NFCTagReaderSession(pollingOption: [.iso14443], delegate: self, queue: nil)
+        self.readerSession = session
+
+        DispatchQueue.main.async {
+            self.updateReaderSessionMessage(alertMessage: NFCViewDisplayMessage.requestPresentPassport)
+            self.readerSession?.begin()
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                guard let self = self else { return }
+                if !self.sessionDidBecomeActive {
+                    self.startSessionWithRetry(retryCount: retryCount - 1)
+                }
+            }
+        }
+    }
+
+
 }
 
 @available(iOS 15, *)
@@ -141,18 +149,20 @@ extension PassportReader : NFCTagReaderSessionDelegate {
         // If necessary, you may perform additional operations on session start.
         // At this point RF polling is enabled.
         Logger.passportReader.debug( "tagReaderSessionDidBecomeActive" )
+        sessionDidBecomeActive = true
     }
-    
+
     public func tagReaderSession(_ session: NFCTagReaderSession, didInvalidateWithError error: Error) {
         // If necessary, you may handle the error. Note session is no longer valid.
         // You must create a new session to restart RF polling.
         Logger.passportReader.debug( "tagReaderSession:didInvalidateWithError - \(error.localizedDescription)" )
         self.readerSession?.invalidate()
         self.readerSession = nil
+        sessionDidBecomeActive = false
 
         if let readerError = error as? NFCReaderError, readerError.code == NFCReaderError.readerSessionInvalidationErrorUserCanceled
             && self.shouldNotReportNextReaderSessionInvalidationErrorUserCanceled {
-            
+
             self.shouldNotReportNextReaderSessionInvalidationErrorUserCanceled = false
         } else {
             var userError = NFCPassportReaderError.UnexpectedError
@@ -162,9 +172,6 @@ extension PassportReader : NFCTagReaderSessionDelegate {
                 case NFCReaderError.readerSessionInvalidationErrorUserCanceled:
                     Logger.passportReader.error( "     - User cancelled session" )
                     userError = NFCPassportReaderError.UserCanceled
-                case NFCReaderError.readerSessionInvalidationErrorSessionTimeout:
-                    Logger.passportReader.error("     - Session timeout")
-                    userError = NFCPassportReaderError.TimeOutError
                 default:
                     Logger.passportReader.error( "     - some other error - \(readerError.localizedDescription)" )
                     userError = NFCPassportReaderError.UnexpectedError
@@ -176,7 +183,7 @@ extension PassportReader : NFCTagReaderSessionDelegate {
             nfcContinuation = nil
         }
     }
-    
+
     public func tagReaderSession(_ session: NFCTagReaderSession, didDetect tags: [NFCTag]) {
         Logger.passportReader.debug( "tagReaderSession:didDetect - found \(tags)" )
         if tags.count > 1 {
@@ -199,20 +206,20 @@ extension PassportReader : NFCTagReaderSessionDelegate {
             self.invalidateSession(errorMessage:errorMessage, error: NFCPassportReaderError.TagNotValid)
             return
         }
-        
+
         Task { [passportTag] in
             do {
                 try await session.connect(to: tag)
-                
+
                 Logger.passportReader.debug( "tagReaderSession:connected to tag - starting authentication" )
                 self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.authenticatingWithPassport(0) )
-                
+
                 let tagReader = TagReader(tag:passportTag)
-                
+
                 if let newAmount = self.dataAmountToReadOverride {
                     tagReader.overrideDataAmountToRead(newAmount: newAmount)
                 }
-                
+
                 tagReader.progress = { [unowned self] (progress) in
                     if let dgId = self.currentlyReadingDataGroup {
                         self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.readingDataGroupProgress(dgId, progress) )
@@ -220,33 +227,23 @@ extension PassportReader : NFCTagReaderSessionDelegate {
                         self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.authenticatingWithPassport(progress) )
                     }
                 }
-                
+
                 let passportModel = try await self.startReading( tagReader : tagReader)
                 nfcContinuation?.resume(returning: passportModel)
                 nfcContinuation = nil
 
-                
+
             } catch let error as NFCPassportReaderError {
                 let errorMessage = NFCViewDisplayMessage.error(error)
                 self.invalidateSession(errorMessage: errorMessage, error: error)
-            } catch {
+            } catch let error {
                 Logger.passportReader.debug( "tagReaderSession:failed to connect to tag - \(error.localizedDescription)" )
-
-                // .readerTransceiveErrorTagResponseError is thrown when a "connection lost" scenario is forced by moving the phone away from the NFC chip
-                // .readerTransceiveErrorTagConnectionLost is never thrown for this scenario, but added for the sake of completeness
-                if let nfcError = error as? NFCReaderError,
-                   nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagResponseError.rawValue ||
-                    nfcError.errorCode == NFCReaderError.readerTransceiveErrorTagConnectionLost.rawValue {
-                    let errorMessage = NFCViewDisplayMessage.error(NFCPassportReaderError.ConnectionError)
-                    self.invalidateSession(errorMessage: errorMessage, error: NFCPassportReaderError.ConnectionError)
-                } else {
-                    let errorMessage = NFCViewDisplayMessage.error(NFCPassportReaderError.Unknown(error))
-                    self.invalidateSession(errorMessage: errorMessage, error: NFCPassportReaderError.Unknown(error))
-                }
+                let errorMessage = NFCViewDisplayMessage.error(NFCPassportReaderError.ConnectionError)
+                self.invalidateSession(errorMessage: errorMessage, error: NFCPassportReaderError.Unknown(error))
             }
         }
     }
-    
+
     func updateReaderSessionMessage(alertMessage: NFCViewDisplayMessage ) {
         self.readerSession?.alertMessage = self.nfcViewDisplayMessageHandler?(alertMessage) ?? alertMessage.description
     }
@@ -254,51 +251,35 @@ extension PassportReader : NFCTagReaderSessionDelegate {
 
 @available(iOS 15, *)
 extension PassportReader {
-    
+
     func startReading(tagReader : TagReader) async throws -> NFCPassportModel {
-        trackingDelegate?.nfcTagDetected()
 
         if !skipPACE {
             do {
-                trackingDelegate?.paceStarted()
-
                 let data = try await tagReader.readCardAccess()
                 Logger.passportReader.debug( "Read CardAccess - data \(binToHexRep(data))" )
                 let cardAccess = try CardAccess(data)
                 passport.cardAccess = cardAccess
 
-                trackingDelegate?.readCardAccess(cardAccess: cardAccess)
-
                 Logger.passportReader.info( "Starting Password Authenticated Connection Establishment (PACE)" )
-                 
+
                 let paceHandler = try PACEHandler( cardAccess: cardAccess, tagReader: tagReader )
                 try await paceHandler.doPACE(mrzKey: mrzKey )
                 passport.PACEStatus = .success
                 Logger.passportReader.debug( "PACE Succeeded" )
-
-                trackingDelegate?.paceSucceeded()
             } catch {
-                trackingDelegate?.paceFailed()
-
                 passport.PACEStatus = .failed
                 Logger.passportReader.error( "PACE Failed - falling back to BAC" )
             }
-            
+
             _ = try await tagReader.selectPassportApplication()
         }
-        
+
         // If either PACE isn't supported, we failed whilst doing PACE or we didn't even attempt it, then fall back to BAC
         if passport.PACEStatus != .success {
-            do {
-                trackingDelegate?.bacStarted()
-                try await doBACAuthentication(tagReader : tagReader)
-                trackingDelegate?.bacSucceeded()
-            } catch {
-                trackingDelegate?.bacFailed()
-                throw error
-            }
+            try await doBACAuthentication(tagReader : tagReader)
         }
-        
+
         // Now to read the datagroups
         try await readDataGroups(tagReader: tagReader)
 
@@ -313,8 +294,8 @@ extension PassportReader {
 
         return self.passport
     }
-    
-    
+
+
     func doActiveAuthenticationIfNeccessary( tagReader : TagReader) async throws {
         guard self.passport.activeAuthenticationSupported else {
             return
@@ -325,16 +306,16 @@ extension PassportReader {
 
         let challenge = generateRandomUInt8Array(8)
         Logger.passportReader.debug( "Generated Active Authentication challange - \(binToHexRep(challenge))")
-        let response = try await tagReader.doInternalAuthentication(challenge: challenge, useExtendedMode: useExtendedMode)
+        let response = try await tagReader.doInternalAuthentication(challenge: challenge)
         self.passport.verifyActiveAuthentication( challenge:challenge, signature:response.data )
     }
-    
+
 
     func doBACAuthentication(tagReader : TagReader) async throws {
         self.currentlyReadingDataGroup = nil
 
         Logger.passportReader.info( "Starting Basic Access Control (BAC)" )
-        
+
         self.passport.BACStatus = .failed
 
         self.bacHandler = BACHandler( tagReader: tagReader )
@@ -345,26 +326,28 @@ extension PassportReader {
     }
 
     func readDataGroups( tagReader: TagReader ) async throws {
-        
+
         // Read COM
         var DGsToRead = [DataGroupId]()
 
         self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.readingDataGroupProgress(.COM, 0) )
-        
         if let com = try await readDataGroup(tagReader:tagReader, dgId:.COM) as? COM {
             self.passport.addDataGroup( .COM, dataGroup:com )
-            self.addDatagroupsToRead(com: com, to: &DGsToRead)
+
+            // SOD and COM shouldn't be present in the DG list but just in case (worst case here we read the sod twice)
+            DGsToRead = [.SOD] + com.dataGroupsPresent.map { DataGroupId.getIDFromName(name:$0) }
+            DGsToRead.removeAll { $0 == .COM }
         }
-        
+
         if DGsToRead.contains( .DG14 ) {
             DGsToRead.removeAll { $0 == .DG14 }
-            
+
             if !skipCA {
                 // Do Chip Authentication
                 if let dg14 = try await readDataGroup(tagReader:tagReader, dgId:.DG14) as? DataGroup14 {
                     self.passport.addDataGroup( .DG14, dataGroup:dg14 )
                     let caHandler = ChipAuthenticationHandler(dg14: dg14, tagReader: tagReader)
-                     
+
                     if caHandler.isChipAuthenticationSupported {
                         do {
                             // Do Chip authentication and then continue reading datagroups
@@ -373,7 +356,7 @@ extension PassportReader {
                         } catch {
                             Logger.passportReader.info( "Chip Authentication failed - re-establishing BAC")
                             self.passport.chipAuthenticationStatus = .failed
-                            
+
                             // Failed Chip Auth, need to re-establish BAC
                             try await doBACAuthentication(tagReader: tagReader)
                         }
@@ -397,14 +380,14 @@ extension PassportReader {
             }
         }
     }
-    
+
     func readDataGroup( tagReader : TagReader, dgId : DataGroupId ) async throws -> DataGroup?  {
 
         self.currentlyReadingDataGroup = dgId
         Logger.passportReader.info( "Reading tag - \(dgId.getName())" )
         var readAttempts = 0
         var nfcPassportReaderError: NFCPassportReaderError
-        
+
         self.updateReaderSessionMessage( alertMessage: NFCViewDisplayMessage.readingDataGroupProgress(dgId, 0) )
 
         repeat {
@@ -441,12 +424,8 @@ extension PassportReader {
                     // OK passport can't handle max length so drop it down
                     tagReader.reduceDataReadingAmount()
                     redoBAC = true
-                } else if errMsg == "UnsupportedDataGroup" {
-                    // OK, this DataGroup is not supported, lets skip it
-                    Logger.passportReader.debug("Unsupported DataGroup - \(dgId.rawValue)")
-                    return nil
                 }
-                
+
                 if redoBAC {
                     // Redo BAC and try again
                     try await doBACAuthentication(tagReader : tagReader)
@@ -468,14 +447,7 @@ extension PassportReader {
         self.readerSession?.invalidate(errorMessage: self.nfcViewDisplayMessageHandler?(errorMessage) ?? errorMessage.description)
         nfcContinuation?.resume(throwing: error)
         nfcContinuation = nil
-    }
-    
-    internal func addDatagroupsToRead(com: COM, to DGsToRead: inout [DataGroupId]) {
-        DGsToRead += com.dataGroupsPresent.compactMap { DataGroupId.getIDFromName(name:$0) }
-        DGsToRead.removeAll { $0 == .COM }
-        
-        // SOD should not be present in COM, but just in case we check before adding it so its not read twice
-        if !DGsToRead.contains(.SOD) { DGsToRead.insert(.SOD, at: 0) }
+        sessionDidBecomeActive = false
     }
 }
 #endif

--- a/Sources/NFCPassportReader/TagReader.swift
+++ b/Sources/NFCPassportReader/TagReader.swift
@@ -177,6 +177,12 @@ public class TagReader {
         // Header looks like:  <tag><length of data><nextTag> e.g.60145F01 -
         // the total length is the 2nd value plus the two header 2 bytes
         // We've read 4 bytes so we now need to read the remaining bytes from offset 4
+
+        guard resp.data.count >= 4 else {
+            Logger.tagReader.error("TagReader - Response data too short: \(resp.data.count) bytes")
+            throw NFCPassportReaderError.UnexpectedError
+        }
+        
         let (len, o) = try! asn1Length([UInt8](resp.data[1..<4]))
         var remaining = Int(len)
         var amountRead = o + 1


### PR DESCRIPTION
## 변경사항
- 간혹 selectFile에서 파일을 4개 이하로 던지는 경우가 있어서 섭스크립트시 인덱스 에러발생 따라서 4이상일때만 핸들링하도록 조건문 추가
- 기기, nfc특성상 기존에 세션을 invalidate해도 계속 살아있는 경우가 있음 이럴때 begin해도 nfc가 실행이 안되는 현상이 발생, 따라서 리트라이 로직을 추가하여 실행이 안되더라도 3번 시도하고 기존에 세션이 살아있다면 세션을 닫고 다시 시도하는 로직 추가
- 유저가 스캔중 또는 시도하려는 도중에 취소를 하면 스캔애니메이션이 사라지지 않고 계속 떠있는 현상이 발생. 이유는 tagReaderSession delegate에 shouldNotReportNextReaderSessionInvalidationErrorUserCanceled 값만 바꾸고 아무런 동작을 안하도록 되어있음 따라서 취소했으니 UserCanceled error 던지도록 처리 (만약 이렇게 된 히스토리가 있다면 히스토리에 따라 핸들링 필요)
- 세션 invalidate시 항상 세션을 초기화 시키도록 함